### PR TITLE
feat: resolve plain name fragment

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -31,12 +31,6 @@
 			<attribute name="m2e-apt" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/src/main/java/ru/fusionsoft/dereferencer/Dereferencer.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/Dereferencer.java
@@ -21,7 +21,8 @@ import ru.fusionsoft.dereferencer.core.schema.ISchemaNode;
 // ---- ...
 //
 // - Refactoring
-// ---- ShcemaNode - refactor executeResolving method
+// ---- SchemaNode
+// ---- SchemaLoader
 //
 // - Tests
 // ---- write integrations tests && fix bugs
@@ -39,7 +40,6 @@ import ru.fusionsoft.dereferencer.core.schema.ISchemaNode;
 // - Dereferencer class
 // ---- feat: method of creating preloaded schemas
 //
-// - feat: plain name fragment resolving
 // - perf: prevention of resource duplicates
 
 public class Dereferencer {
@@ -61,7 +61,7 @@ public class Dereferencer {
         schemaLoader = new SchemaLoader(DereferenceConfiguration.builder().build());
     }
 
-    public Dereferencer(DereferenceConfiguration cfg) throws DereferenceException{
+    public Dereferencer(DereferenceConfiguration cfg) throws DereferenceException {
         schemaLoader = new SchemaLoader(cfg);
     }
 

--- a/src/main/java/ru/fusionsoft/dereferencer/core/routing/Route.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/routing/Route.java
@@ -77,12 +77,6 @@ public class Route {
         return ReferenceFactory.create(canonical.getAbsolute(), URI.create(relative));
     }
 
-    public void setPlainNameToFragmentOfCanonical(String name){
-        Reference canonical=getCanonical();
-        canonical.getJsonPtr().setPlainName(name);
-        availableToFetch.add(canonical);
-    }
-
     static class AvailableToFetch implements Cloneable {
         private Set<Reference> duplicates;
         private Route relatedRoute;

--- a/src/main/java/ru/fusionsoft/dereferencer/core/routing/ref/JsonPtr.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/routing/ref/JsonPtr.java
@@ -13,6 +13,11 @@ public class JsonPtr {
             plainName = fragment;
     }
 
+    public JsonPtr(String jsonPointer, String plainName) {
+        this.jsonPointer = jsonPointer;
+        this.plainName = plainName;
+    }
+
     public boolean isResolved() {
         return jsonPointer != null;
     }
@@ -65,7 +70,7 @@ public class JsonPtr {
     @Override
     public boolean equals(Object obj) {
         JsonPtr rightPtr = (JsonPtr) obj;
-        if(rightPtr.isResolved() && this.isResolved()){
+        if (rightPtr.isResolved() && this.isResolved()) {
             return this.jsonPointer == rightPtr.jsonPointer;
         } else {
             return this.plainName == rightPtr.plainName;

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/RetrievalManager.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/RetrievalManager.java
@@ -25,7 +25,8 @@ public class RetrievalManager {
         setJsonMapper(jsonMapper).setYamlMapper(yamlMapper).setGitHubToken(gitHubToken).setGitLabToken(gitLabToken);
     }
 
-    public JsonNode retrieve(Route route) throws StreamReadException, DatabindException, IOException, DereferenceException {
+    public JsonNode retrieve(Route route)
+            throws StreamReadException, DatabindException, IOException, DereferenceException {
         // TODO
         Reference canonical = route.getCanonical();
         SourceLoader sourceLoader = loaderFactory.getLoader(canonical.getAbsolute());

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/LoaderFactory.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/LoaderFactory.java
@@ -8,19 +8,19 @@ import ru.fusionsoft.dereferencer.core.utils.load.impl.FileLoader;
 import ru.fusionsoft.dereferencer.core.utils.load.impl.GitHubLoader;
 import ru.fusionsoft.dereferencer.core.utils.load.impl.URLLoader;
 
-public class LoaderFactory{
+public class LoaderFactory {
     private FileLoader fileLoader;
     private GitHubLoader gitHubLoader;
     private URLLoader urlLoader;
 
-    public LoaderFactory(){
+    public LoaderFactory() {
         fileLoader = new FileLoader();
         gitHubLoader = new GitHubLoader();
         urlLoader = new URLLoader();
     }
 
-    public SourceLoader getLoader(URI uri) throws URIException{
-        if(isGitHubReference(uri))
+    public SourceLoader getLoader(URI uri) throws URIException {
+        if (isGitHubReference(uri))
             return gitHubLoader;
         else if (isFileSystemReference(uri))
             return fileLoader;
@@ -31,11 +31,11 @@ public class LoaderFactory{
             throw new URIException("");
     }
 
-    public void setGitHubToken(String token){
+    public void setGitHubToken(String token) {
         gitHubLoader.setToken(token);
     }
 
-    public void setGitLabToken(String token){
+    public void setGitLabToken(String token) {
         // TODO ...add gitlab loader
     }
 

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/SourceLoader.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/SourceLoader.java
@@ -7,5 +7,6 @@ import ru.fusionsoft.dereferencer.core.routing.ref.Reference;
 
 public interface SourceLoader {
     public InputStream getSource(Reference ref) throws DereferenceException;
+
     public SupportedSourceTypes getSourceType(Reference ref) throws DereferenceException;
 }

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/SupportedSourceTypes.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/SupportedSourceTypes.java
@@ -1,24 +1,24 @@
 package ru.fusionsoft.dereferencer.core.utils.load;
 
-public enum SupportedSourceTypes{
+public enum SupportedSourceTypes {
     JSON,
     YAML,
     NOT_IMPLEMENTED;
 
-    public boolean isYaml(){
+    public boolean isYaml() {
         return this.equals(YAML);
     }
 
-    public boolean isJson(){
+    public boolean isJson() {
         return this.equals(JSON);
     }
 
-    public boolean isNotImplemented(){
+    public boolean isNotImplemented() {
         return this.equals(NOT_IMPLEMENTED);
     }
 
-    public static SupportedSourceTypes resolveSourceType(String extension){
-        switch(extension){
+    public static SupportedSourceTypes resolveSourceType(String extension) {
+        switch (extension) {
             case "json":
                 return JSON;
             case "yaml":

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/FileLoader.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/FileLoader.java
@@ -12,10 +12,10 @@ import ru.fusionsoft.dereferencer.core.routing.ref.Reference;
 import ru.fusionsoft.dereferencer.core.utils.load.SourceLoader;
 import ru.fusionsoft.dereferencer.core.utils.load.SupportedSourceTypes;
 
-public class FileLoader implements SourceLoader{
+public class FileLoader implements SourceLoader {
 
     @Override
-    public InputStream getSource(Reference ref) throws DereferenceException{
+    public InputStream getSource(Reference ref) throws DereferenceException {
         File file = Paths.get(ref.getAbsolute()).toAbsolutePath().toFile();
         try {
             return new FileInputStream(file);
@@ -28,6 +28,6 @@ public class FileLoader implements SourceLoader{
     @Override
     public SupportedSourceTypes getSourceType(Reference ref) {
         String path = Paths.get(ref.getAbsolute()).toString();
-        return SupportedSourceTypes.resolveSourceType(path.substring(path.lastIndexOf(".") +1));
+        return SupportedSourceTypes.resolveSourceType(path.substring(path.lastIndexOf(".") + 1));
     }
 }

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/GitHubLoader.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/GitHubLoader.java
@@ -15,9 +15,9 @@ import ru.fusionsoft.dereferencer.core.routing.ref.Reference;
 import ru.fusionsoft.dereferencer.core.utils.load.SourceLoader;
 import ru.fusionsoft.dereferencer.core.utils.load.SupportedSourceTypes;
 
-public class GitHubLoader implements SourceLoader{
+public class GitHubLoader implements SourceLoader {
 
-    private String token=null;
+    private String token = null;
 
     @Override
     public InputStream getSource(Reference ref) throws DereferenceException {
@@ -41,13 +41,13 @@ public class GitHubLoader implements SourceLoader{
     @Override
     public SupportedSourceTypes getSourceType(Reference ref) throws DereferenceException {
         String path = ref.getAbsolute().getPath().toString();
-        return SupportedSourceTypes.resolveSourceType(path.substring(path.lastIndexOf(".") +1));
+        return SupportedSourceTypes.resolveSourceType(path.substring(path.lastIndexOf(".") + 1));
     }
 
-    private URI transformUriToApiUri(URI uri) throws URIException{
+    private URI transformUriToApiUri(URI uri) throws URIException {
         String apiGithubHostName = Dereferencer.PROPERTIES.getProperty("refs.hostname.api-github");
 
-        if(uri.getHost().equals(apiGithubHostName))
+        if (uri.getHost().equals(apiGithubHostName))
             return uri;
 
         String[] uriPath = uri.getPath().split("/");
@@ -57,10 +57,10 @@ public class GitHubLoader implements SourceLoader{
 
         try {
             resultUri = new URI(
-                                uri.getScheme(), uri.getUserInfo(),
-                                apiGithubHostName,
-                                uri.getPort(), resultPath,
-                                "ref=" + uriPath[4], uri.getFragment());
+                    uri.getScheme(), uri.getUserInfo(),
+                    apiGithubHostName,
+                    uri.getPort(), resultPath,
+                    "ref=" + uriPath[4], uri.getFragment());
         } catch (URISyntaxException e) {
             throw new URIException(resultPath);
         }
@@ -68,7 +68,7 @@ public class GitHubLoader implements SourceLoader{
         return resultUri;
     }
 
-    public void setToken(String token){
+    public void setToken(String token) {
         this.token = token;
     }
 }

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/GitLabLoader.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/GitLabLoader.java
@@ -7,9 +7,9 @@ import ru.fusionsoft.dereferencer.core.routing.ref.Reference;
 import ru.fusionsoft.dereferencer.core.utils.load.SourceLoader;
 import ru.fusionsoft.dereferencer.core.utils.load.SupportedSourceTypes;
 
-public class GitLabLoader implements SourceLoader{
+public class GitLabLoader implements SourceLoader {
 
-    private String token=null;
+    private String token = null;
 
     @Override
     public InputStream getSource(Reference ref) throws DereferenceException {
@@ -23,7 +23,7 @@ public class GitLabLoader implements SourceLoader{
         return null;
     }
 
-    public void setToken(String token){
+    public void setToken(String token) {
         this.token = token;
     }
 }

--- a/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/URLLoader.java
+++ b/src/main/java/ru/fusionsoft/dereferencer/core/utils/load/impl/URLLoader.java
@@ -9,7 +9,7 @@ import ru.fusionsoft.dereferencer.core.routing.ref.Reference;
 import ru.fusionsoft.dereferencer.core.utils.load.SourceLoader;
 import ru.fusionsoft.dereferencer.core.utils.load.SupportedSourceTypes;
 
-public class URLLoader implements SourceLoader{
+public class URLLoader implements SourceLoader {
 
     @Override
     public InputStream getSource(Reference ref) throws DereferenceException {


### PR DESCRIPTION
Resolving occurs when schema 'A' searches within itself for children (subschemas) and finds subschema 'B' with the $anchor key. Scheme 'A' creates a JsonPtr that stores a pointer by which possible get subschema 'B' and its plain name which is equal to the value of the anchor. After that, when requesting this plain name, subschema 'B' will be returned. Schemas that have previously tried to get this fragment will also receive it, due to the MissingSchemaNode wrapper, into which schema 'A' will put subschema 'B'